### PR TITLE
Fix DoH base64 encoding

### DIFF
--- a/doh.go
+++ b/doh.go
@@ -66,8 +66,8 @@ func (c DoHClient) Query(ctx context.Context, msg *dns.Msg) ([]dns.RR, time.Dura
 		return []dns.RR{}, time.Since(start), err
 	}
 	// convert to base64
-	dohbase64 := base64.StdEncoding.EncodeToString(dohbytes)
-	dohbase64 = strings.TrimSuffix(dohbase64, "=")
+	dohbase64 := base64.URLEncoding.EncodeToString(dohbytes)
+	dohbase64 = strings.TrimRight(dohbase64, "=")
 	q := c.req.URL.Query()
 	q.Set("dns", dohbase64)
 	c.req.URL.RawQuery = q.Encode()


### PR DESCRIPTION
Thanks for your awesome package.
I'm trying to debug the problem I have with your sniproxy and I ended up with using DoH, but I see that `TrimSuffix` can't actually trim `=`s if there are more than one, but `TrimRight` does. Also the right encoding should be URL encoding, not the standard one. Please make sure that I'm not wrong about it and please accept this small PR if I'm right. Thanks